### PR TITLE
include <cstdint> to fix build errors

### DIFF
--- a/common/str.h
+++ b/common/str.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <sstream>


### PR DESCRIPTION
The compiler complains about undefined integer types, like uint8_t, etc. The header should include <cstdint> first.